### PR TITLE
Makes text in the sidewrap wrap

### DIFF
--- a/plugins/notebook/base.tid
+++ b/plugins/notebook/base.tid
@@ -217,7 +217,7 @@ h1.tc-site-title {
   text-overflow: ellipsis;
   padding-top: 10px;
   z-index: 500;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .nc-sidebar .segment {


### PR DESCRIPTION
Text that is in the sidebar stays on one line and is unreadable past a certain point. Changing white-space: no-wrap; to normal in .nc-sidebar changes that.